### PR TITLE
ActiveModel::Lint::Tests and make #persisted? return a boolean

### DIFF
--- a/lib/active_node/persistence.rb
+++ b/lib/active_node/persistence.rb
@@ -85,7 +85,7 @@ module ActiveNode
     end
 
     def persisted?
-      id
+      id.present?
     end
 
     def initialize hash={}, split_by=:respond_to_writer?

--- a/spec/functional/base_spec.rb
+++ b/spec/functional/base_spec.rb
@@ -15,4 +15,6 @@ describe ActiveNode::Base do
       ActiveNode::Base.subclass('Person').find(p.id)[:name].should == p.name
     end
   end
+
+  it_behaves_like "ActiveModel"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ Coveralls.wear!
 
 Dir[File.dirname(__FILE__) + '/models/*.rb'].each {|file| require file }
 
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
+
 def generate_text(length=8)
   chars = 'abcdefghjkmnpqrstuvwxyz'
   key = ''
@@ -50,10 +54,10 @@ end
 def error_response(attributes)
   request_uri = double()
   request_uri.stub(:request_uri).and_return("")
-  
+
   http_header = double()
   http_header.stub(:request_uri).and_return(request_uri)
-  
+
   stub(
     http_header: http_header,
     code: attributes[:code],

--- a/spec/support/shared/active_model_specs.rb
+++ b/spec/support/shared/active_model_specs.rb
@@ -1,0 +1,23 @@
+# Adapated from http://pivotallabs.com/making-sure-you-implement-the-activemodel-interface-fully/
+#
+# Originally adapted from rspec-rails http://github.com/rspec/rspec-rails/blob/master/spec/rspec/rails/mocks/mock_model_spec.rb
+# put this in a file in your spec/support directory
+# USAGE:
+#
+#    let(:model) { ModelUnderTest.new(params) }
+#    it_behaves_like "ActiveModel"
+
+shared_examples_for "ActiveModel" do
+  require 'test/unit/assertions'
+  require 'active_model/lint'
+  include Test::Unit::Assertions
+  include ActiveModel::Lint::Tests
+
+  ActiveModel::Lint::Tests.public_instance_methods.map { |method| method.to_s }.grep(/^test/).each do |method|
+    example(method.gsub('_', ' ')) { send method }
+  end
+
+  def model
+    subject
+  end
+end


### PR DESCRIPTION
I was having an issue where rails wasn't handling my ActiveNode models correctly, so I added ActiveModel::Lint::Tests to see what was going on. One of the tests failed and said #persisted? needs to return a boolean. Here is the fix I came up with.
