### PR TITLE
Makes #to_param return a string

### DIFF
--- a/lib/active_node/persistence.rb
+++ b/lib/active_node/persistence.rb
@@ -81,7 +81,7 @@ module ActiveNode
     end
 
     def to_param
-      id
+      id.to_s
     end
 
     def persisted?

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -80,6 +80,13 @@ describe ActiveNode::Persistence do
     end
   end
 
+  describe "#to_param" do
+    it "should return a string version of the id" do
+      person = Person.create!
+      person.to_param.should == person.id.to_s
+    end
+  end
+
   describe "#incoming" do
     it "can retrieve heterogenous models" do
       a = Address.create!


### PR DESCRIPTION
I was running into issues with using some of the rails url helpers and tracked the issue down to #to_param returning a FixNum instead of a String. I double checked the [rails guides](http://guides.rubyonrails.org/active_support_core_extensions.html#to-param) and that method is supposed to return a string.
