### PR TITLE
Fixes ActiveModel to_param lint error

### DIFF
--- a/lib/active_node/persistence.rb
+++ b/lib/active_node/persistence.rb
@@ -81,7 +81,7 @@ module ActiveNode
     end
 
     def to_param
-      id.to_s
+      id.to_s if persisted?
     end
 
     def persisted?

--- a/spec/functional/persistence_spec.rb
+++ b/spec/functional/persistence_spec.rb
@@ -85,6 +85,11 @@ describe ActiveNode::Persistence do
       person = Person.create!
       person.to_param.should == person.id.to_s
     end
+
+    it "should return nil if the id is nil" do
+      person = Person.new
+      person.to_param.should be_nil
+    end
   end
 
   describe "#incoming" do


### PR DESCRIPTION
This fixes the following build error: ActiveNode::Base behaves like ActiveModel test to param. Looks like it was caused when the last two pull requests were merged together. Sorry, about that.
